### PR TITLE
Slither recommendation fixes (SC-4903) 

### DIFF
--- a/contracts/xMPL.sol
+++ b/contracts/xMPL.sol
@@ -54,14 +54,14 @@ contract xMPL is IxMPL, RevenueDistributionToken {
         uint256 amountToMigrate        = currentAsset.balanceOf(address(this));
         uint256 balanceBeforeMigration = newAsset.balanceOf(address(this));
 
+        asset = newAsset_;
+
+        _cleanupMigration();
+
         require(currentAsset.approve(migrator_, amountToMigrate), "xMPL:PM:APPROVAL_FAILED");
         migrator.migrate(amountToMigrate);
 
         require(newAsset.balanceOf(address(this)) - balanceBeforeMigration == amountToMigrate, "xMPL:PM:WRONG_AMOUNT");
-
-        asset = newAsset_;
-
-        _cleanupMigration();
 
         emit MigrationPerformed(amountToMigrate);
     }


### PR DESCRIPTION
- Retrancy attack possibility, adopted check-effects-interactions pattern, before performing the token migration. Not possible as its a permissioned call, but a good habit to get into, + auditors won't waste time on it
- require() check on approve() to use the return value