### PR TITLE
fix: Use match-path to get xMPL only tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,10 +11,11 @@ done
 
 export FOUNDRY_PROFILE=$profile
 
-if [ -z "$test" ]; then match="[src/test/*.t.sol]"; else match=$test; fi
-
 echo Using profile: $FOUNDRY_PROFILE
 
-rm -rf out
-
-forge test --match "$match" -vvv
+if [ -z "$test" ];
+then
+    forge test -vvv --match-path "$PWD/contracts/test/*";
+else
+    forge test --match "$match" -vvv;
+fi

--- a/test.sh
+++ b/test.sh
@@ -15,7 +15,7 @@ echo Using profile: $FOUNDRY_PROFILE
 
 if [ -z "$test" ];
 then
-    forge test -vvv --match-path "$PWD/contracts/test/*";
+    forge test --match-path "$PWD/contracts/test/*";
 else
-    forge test --match "$match" -vvv;
+    forge test --match "$match";
 fi

--- a/test.sh
+++ b/test.sh
@@ -17,5 +17,5 @@ if [ -z "$test" ];
 then
     forge test --match-path "$PWD/contracts/test/*";
 else
-    forge test --match "$match";
+    forge test --match "$test";
 fi


### PR DESCRIPTION
Use path to avoid running tests from inherited contracts.